### PR TITLE
minor: fix typos

### DIFF
--- a/learning/notebooks/locomotion.ipynb
+++ b/learning/notebooks/locomotion.ipynb
@@ -970,7 +970,7 @@
         "id": "v5p0Z3PPSRik"
       },
       "source": [
-        "Notive that the above policy looks jittery and unlikely to transfer on the robot. The max power outut is also quite high.\n",
+        "Notice that the above policy looks jittery and unlikely to transfer on the robot. The max power output is also quite high.\n",
         "\n",
         "The sim-to-real deployment of the handstand policy was trained using a curriculum on the `energy_termination_threshold`, `energy` and `dof_acc`, which are config values that penalize high torques and high power output. Let's finetune the above policy with a decreased  `energy_termination_threshold`, as well as non-zero values for `energy` and `dof_acc` rewards to get a smoother policy."
       ]


### PR DESCRIPTION
Minor change to the locomotion.ipynb notebook to fix typos. 