### PR TITLE
Fix: Use env_cfg.to_dict() to avoid double JSON serialization (#43)

### DIFF
--- a/learning/notebooks/locomotion.ipynb
+++ b/learning/notebooks/locomotion.ipynb
@@ -798,7 +798,7 @@
         "print(f\"{ckpt_path}\")\n",
         "\n",
         "with open(ckpt_path / \"config.json\", \"w\") as fp:\n",
-        "  json.dump(env_cfg.to_json(), fp, indent=4)"
+        "  json.dump(env_cfg.to_dict(), fp, indent=4)"
       ]
     },
     {

--- a/learning/train_jax_ppo.py
+++ b/learning/train_jax_ppo.py
@@ -266,7 +266,7 @@ def main(argv):
 
   # Save environment configuration
   with open(ckpt_path / "config.json", "w", encoding="utf-8") as fp:
-    json.dump(env_cfg.to_json(), fp, indent=4)
+    json.dump(env_cfg.to_dict(), fp, indent=4)
 
   # Define policy parameters function for saving checkpoints
   def policy_params_fn(current_step, make_policy, params):  # pylint: disable=unused-argument

--- a/learning/train_rsl_rl.py
+++ b/learning/train_rsl_rl.py
@@ -139,7 +139,7 @@ def main(argv):
   with open(
       os.path.join(ckpt_path, "config.json"), "w", encoding="utf-8"
   ) as fp:
-    json.dump(env_cfg.to_json(), fp, indent=4)
+    json.dump(env_cfg.to_dict(), fp, indent=4)
 
   # Domain randomization
   randomizer = registry.get_domain_randomizer(_ENV_NAME.value)

--- a/mujoco_playground/experimental/learning/cube_reorient.ipynb
+++ b/mujoco_playground/experimental/learning/cube_reorient.ipynb
@@ -158,7 +158,7 @@
     "print(f\"{ckpt_path}\")\n",
     "\n",
     "with open(ckpt_path / \"config.json\", \"w\") as fp:\n",
-    "  json.dump(env_cfg.to_json(), fp, indent=4)"
+    "  json.dump(env_cfg.to_dict(), fp, indent=4)"
    ]
   },
   {

--- a/mujoco_playground/experimental/learning/cube_rotate.ipynb
+++ b/mujoco_playground/experimental/learning/cube_rotate.ipynb
@@ -143,7 +143,7 @@
     "print(f\"{ckpt_path}\")\n",
     "\n",
     "with open(ckpt_path / \"config.json\", \"w\") as fp:\n",
-    "  json.dump(env_cfg.to_json(), fp, indent=4)"
+    "  json.dump(env_cfg.to_dict(), fp, indent=4)"
    ]
   },
   {

--- a/mujoco_playground/experimental/learning/gait_tracking.ipynb
+++ b/mujoco_playground/experimental/learning/gait_tracking.ipynb
@@ -135,7 +135,7 @@
     "print(f\"Checkpoint path: {ckpt_path}\")\n",
     "\n",
     "with open(ckpt_path / \"config.json\", \"w\") as fp:\n",
-    "  json.dump(env_cfg.to_json(), fp, indent=4)\n",
+    "  json.dump(env_cfg.to_dict(), fp, indent=4)\n",
     "\n",
     "\n",
     "def policy_params_fn(current_step, make_policy, params):\n",

--- a/mujoco_playground/experimental/learning/getup.ipynb
+++ b/mujoco_playground/experimental/learning/getup.ipynb
@@ -155,7 +155,7 @@
     "print(f\"{ckpt_path}\")\n",
     "\n",
     "with open(ckpt_path / \"config.json\", \"w\") as fp:\n",
-    "  json.dump(env_cfg.to_json(), fp, indent=4)"
+    "  json.dump(env_cfg.to_dict(), fp, indent=4)"
    ]
   },
   {

--- a/mujoco_playground/experimental/learning/handstand.ipynb
+++ b/mujoco_playground/experimental/learning/handstand.ipynb
@@ -150,7 +150,7 @@
     "print(f\"{ckpt_path}\")\n",
     "\n",
     "with open(ckpt_path / \"config.json\", \"w\") as fp:\n",
-    "  json.dump(env_cfg.to_json(), fp, indent=4)"
+    "  json.dump(env_cfg.to_dict(), fp, indent=4)"
    ]
   },
   {

--- a/mujoco_playground/experimental/learning/humanoid_joystick.ipynb
+++ b/mujoco_playground/experimental/learning/humanoid_joystick.ipynb
@@ -159,7 +159,7 @@
     "print(f\"{ckpt_path}\")\n",
     "\n",
     "with open(ckpt_path / \"config.json\", \"w\") as fp:\n",
-    "  json.dump(env_cfg.to_json(), fp, indent=4)"
+    "  json.dump(env_cfg.to_dict(), fp, indent=4)"
    ]
   },
   {

--- a/mujoco_playground/experimental/learning/humanoid_joystick_gait_tracking.ipynb
+++ b/mujoco_playground/experimental/learning/humanoid_joystick_gait_tracking.ipynb
@@ -128,7 +128,7 @@
     "print(f\"Checkpoint path: {ckpt_path}\")\n",
     "\n",
     "with open(ckpt_path / \"config.json\", \"w\") as fp:\n",
-    "  json.dump(env_cfg.to_json(), fp, indent=4)\n",
+    "  json.dump(env_cfg.to_dict(), fp, indent=4)\n",
     "\n",
     "\n",
     "def policy_params_fn(current_step, make_policy, params):\n",

--- a/mujoco_playground/experimental/learning/joystick.ipynb
+++ b/mujoco_playground/experimental/learning/joystick.ipynb
@@ -157,7 +157,7 @@
     "print(f\"Checkpoint path: {ckpt_path}\")\n",
     "\n",
     "with open(ckpt_path / \"config.json\", \"w\") as fp:\n",
-    "  json.dump(env_cfg.to_json(), fp, indent=4)"
+    "  json.dump(env_cfg.to_dict(), fp, indent=4)"
    ]
   },
   {

--- a/mujoco_playground/experimental/learning/joystick_gait_tracking.ipynb
+++ b/mujoco_playground/experimental/learning/joystick_gait_tracking.ipynb
@@ -128,7 +128,7 @@
     "print(f\"Checkpoint path: {ckpt_path}\")\n",
     "\n",
     "with open(ckpt_path / \"config.json\", \"w\") as fp:\n",
-    "  json.dump(env_cfg.to_json(), fp, indent=4)\n",
+    "  json.dump(env_cfg.to_dict(), fp, indent=4)\n",
     "\n",
     "\n",
     "def policy_params_fn(current_step, make_policy, params):\n",

--- a/mujoco_playground/experimental/learning/open_cabinet.ipynb
+++ b/mujoco_playground/experimental/learning/open_cabinet.ipynb
@@ -103,7 +103,7 @@
     "print(f\"Checkpoint path: {ckpt_path}\")\n",
     "\n",
     "with open(ckpt_path / \"config.json\", \"w\") as fp:\n",
-    "  json.dump(env_cfg.to_json(), fp, indent=4)\n",
+    "  json.dump(env_cfg.to_dict(), fp, indent=4)\n",
     "\n",
     "\n",
     "def policy_params_fn(current_step, make_policy, params):\n",

--- a/mujoco_playground/experimental/learning/position_cube.ipynb
+++ b/mujoco_playground/experimental/learning/position_cube.ipynb
@@ -134,7 +134,7 @@
     "print(f\"Checkpoint path: {ckpt_path}\")\n",
     "\n",
     "with open(ckpt_path / \"config.json\", \"w\") as fp:\n",
-    "  json.dump(env_cfg.to_json(), fp, indent=4)\n",
+    "  json.dump(env_cfg.to_dict(), fp, indent=4)\n",
     "\n",
     "\n",
     "def policy_params_fn(current_step, make_policy, params):\n",


### PR DESCRIPTION
This PR fixes issue https://github.com/google-deepmind/mujoco_playground/issues/43 by replacing
 `json.dump(env_cfg.to_json(), fp, indent=4)` 
with 
`json.dump(env_cfg.to_dict(), fp, indent=4)`
following the original suggestion.