### PR TITLE
add note about TF32 precision on Ampere architectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,6 @@ pip install playground
 6. Install playground: `uv pip install -e ".[all]"`
 7. Verify installation (and download Menagerie): `python -c "import mujoco_playground"`
 
-#### Important Note on GPU Precision:
-Users with NVIDIA Ampere architecture GPUs (e.g., RTX 30 and 40 series) may experience reproducibility issues in mujoco_playground due to JAX’s default use of TF32 for matrix multiplications. This lower precision can adversely affect RL training stability. To ensure consistent behavior with systems using full float32 precision (as on Turing GPUs), please run `export JAX_DEFAULT_MATMUL_PRECISION=highest` in your terminal before starting your experiments (or add it to the end of `~/.bashrc`).
-
 #### Madrona-MJX (optional)
 
 For vision-based environments, please refer to the installation instructions in the [Madrona-MJX](https://github.com/shacklettbp/madrona_mjx?tab=readme-ov-file#installation) repository.
@@ -66,9 +63,15 @@ For vision-based environments, please refer to the installation instructions in 
 | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google-deepmind/mujoco_playground/blob/main/learning/notebooks/training_vision_1.ipynb) | Training CartPole from Vision |
 | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google-deepmind/mujoco_playground/blob/main/learning/notebooks/training_vision_2.ipynb) | Robotic Manipulation from Vision |
 
-## How can I contribute?
+
+## FAQ
+
+### How can I contribute?
 
 Get started by installing the library and exploring its features! Found a bug? Report it in the issue tracker. Interested in contributing? If you are a developer with robotics experience, we would love your help—check out the [contribution guidelines](CONTRIBUTING.md) for more details.
+
+### Reproducibility / GPU Precision Issues
+Users with NVIDIA Ampere architecture GPUs (e.g., RTX 30 and 40 series) may experience reproducibility [issues](https://github.com/google-deepmind/mujoco_playground/issues/86) in mujoco_playground due to JAX’s default use of TF32 for matrix multiplications. This lower precision can adversely affect RL training stability. To ensure consistent behavior with systems using full float32 precision (as on Turing GPUs), please run `export JAX_DEFAULT_MATMUL_PRECISION=highest` in your terminal before starting your experiments (or add it to the end of `~/.bashrc`).
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ pip install playground
 6. Install playground: `uv pip install -e ".[all]"`
 7. Verify installation (and download Menagerie): `python -c "import mujoco_playground"`
 
+#### Important Note on GPU Precision:
+Users with NVIDIA Ampere architecture GPUs (e.g., RTX 30 and 40 series) may experience reproducibility issues in mujoco_playground due to JAX’s default use of TF32 for matrix multiplications. This lower precision can adversely affect RL training stability. To ensure consistent behavior with systems using full float32 precision (as on Turing GPUs), please run `export JAX_DEFAULT_MATMUL_PRECISION=highest` in your terminal before starting your experiments (or add it to the end of `~/.bashrc`).
+
 #### Madrona-MJX (optional)
 
 For vision-based environments, please refer to the installation instructions in the [Madrona-MJX](https://github.com/shacklettbp/madrona_mjx?tab=readme-ov-file#installation) repository.


### PR DESCRIPTION
This is to fix the issue that I reported in https://github.com/google-deepmind/mujoco_playground/issues/86