### PR TITLE
Fix get_qpos_ids

### DIFF
--- a/mujoco_playground/_src/mjx_env.py
+++ b/mujoco_playground/_src/mjx_env.py
@@ -376,7 +376,7 @@ def get_qpos_ids(
   for jnt_name in joint_names:
     jnt = model.joint(jnt_name).id
     jnt_type = model.jnt_type[jnt]
-    qadr = model.jnt_dofadr[jnt]
+    qadr = model.jnt_qposadr[jnt]
     qdim = qpos_width(jnt_type)
     index_list.extend(range(qadr, qadr + qdim))
   return np.array(index_list)


### PR DESCRIPTION
This fixes the function `get_qpos_ids` in `mjx_env.py`. The original code was using the wrong call, causing issues when you have free joints in the model. It did not cause issues when the function was used for models with free joints at the last index (e.g. Leap Hand). 