### PR TITLE
Patch new field light_type

### DIFF
--- a/mujoco_playground/_src/manipulation/franka_emika_panda/randomize_vision.py
+++ b/mujoco_playground/_src/manipulation/franka_emika_panda/randomize_vision.py
@@ -72,7 +72,7 @@ def domain_randomize(
       'cam_quat': 0,
       'light_pos': 0,
       'light_dir': 0,
-      'light_directional': 0,
+      'light_type': 0,
       'light_castshadow': 0,
   })
   rng = jax.random.key(0)
@@ -151,7 +151,7 @@ def domain_randomize(
     ).astype(jp.float32)
 
     # No need to randomize into specular lighting
-    light_directional = jp.ones((nlight,))
+    light_type = jp.ones((nlight,))
 
     return (
         geom_rgba,
@@ -159,7 +159,7 @@ def domain_randomize(
         cam_pos,
         cam_quat,
         light_dir,
-        light_directional,
+        light_type,
         light_castshadow,
     )
 
@@ -169,7 +169,7 @@ def domain_randomize(
       cam_pos,
       cam_quat,
       light_dir,
-      light_directional,
+      light_type,
       light_castshadow,
   ) = rand(jax.random.split(rng, num_worlds), light_positions)
 
@@ -180,7 +180,7 @@ def domain_randomize(
       'cam_quat': cam_quat,
       'light_pos': light_positions,
       'light_dir': light_dir,
-      'light_directional': light_directional,
+      'light_type': light_type,
       'light_castshadow': light_castshadow,
   })
 

--- a/mujoco_playground/_src/wrapper.py
+++ b/mujoco_playground/_src/wrapper.py
@@ -196,7 +196,7 @@ def _identity_vision_randomization_fn(
       'geom_size': 0,
       'light_pos': 0,
       'light_dir': 0,
-      'light_directional': 0,
+      'light_type': 0,
       'light_castshadow': 0,
       'light_cutoff': 0,
   })
@@ -218,8 +218,8 @@ def _identity_vision_randomization_fn(
       'light_dir': jp.repeat(
           jp.expand_dims(mjx_model.light_dir, 0), num_worlds, axis=0
       ),
-      'light_directional': jp.repeat(
-          jp.expand_dims(mjx_model.light_directional, 0), num_worlds, axis=0
+      'light_type': jp.repeat(
+          jp.expand_dims(mjx_model.light_type, 0), num_worlds, axis=0
       ),
       'light_castshadow': jp.repeat(
           jp.expand_dims(mjx_model.light_castshadow, 0), num_worlds, axis=0
@@ -245,7 +245,7 @@ def _supplement_vision_randomization_fn(
       'geom_size',
       'light_pos',
       'light_dir',
-      'light_directional',
+      'light_type',
       'light_castshadow',
       'light_cutoff',
   ]
@@ -292,7 +292,7 @@ class MadronaWrapper:
         'geom_size',
         'light_pos',
         'light_dir',
-        'light_directional',
+        'light_type',
         'light_castshadow',
         'light_cutoff',
     ]


### PR DESCRIPTION
Patch to fix the recent change in mujoco 3.3.3 where the light field was changed from light_direcitonal -> light_type.

Matches the patch made to madrona_mjx: https://github.com/shacklettbp/madrona_mjx/pull/42