### PR TITLE
add _model_assets property to all envs

### DIFF
--- a/mujoco_playground/_src/dm_control_suite/acrobot.py
+++ b/mujoco_playground/_src/dm_control_suite/acrobot.py
@@ -57,8 +57,9 @@ class Balance(mjx_env.MjxEnv):
     self._margin = 0.0 if sparse else 1.0
 
     self._xml_path = _XML_PATH.as_posix()
+    self._model_assets = common.get_assets()
     self._mj_model = mujoco.MjModel.from_xml_string(
-        _XML_PATH.read_text(), common.get_assets()
+        _XML_PATH.read_text(), self._model_assets
     )
     self._mj_model.opt.timestep = self.sim_dt
     self._mjx_model = mjx.put_model(self._mj_model)

--- a/mujoco_playground/_src/dm_control_suite/ball_in_cup.py
+++ b/mujoco_playground/_src/dm_control_suite/ball_in_cup.py
@@ -53,8 +53,9 @@ class BallInCup(mjx_env.MjxEnv):
       )
 
     self._xml_path = _XML_PATH.as_posix()
+    self._model_assets = common.get_assets()
     self._mj_model = mujoco.MjModel.from_xml_string(
-        _XML_PATH.read_text(), common.get_assets()
+        _XML_PATH.read_text(), self._model_assets
     )
     self._mj_model.opt.timestep = self.sim_dt
     self._mjx_model = mjx.put_model(self._mj_model)

--- a/mujoco_playground/_src/dm_control_suite/cheetah.py
+++ b/mujoco_playground/_src/dm_control_suite/cheetah.py
@@ -56,8 +56,9 @@ class Run(mjx_env.MjxEnv):
       )
 
     self._xml_path = _XML_PATH.as_posix()
+    self._model_assets = common.get_assets()
     self._mj_model = mujoco.MjModel.from_xml_string(
-        _XML_PATH.read_text(), common.get_assets()
+        _XML_PATH.read_text(), self._model_assets
     )
     self._mj_model.opt.timestep = self.sim_dt
     self._mjx_model = mjx.put_model(self._mj_model)

--- a/mujoco_playground/_src/dm_control_suite/finger.py
+++ b/mujoco_playground/_src/dm_control_suite/finger.py
@@ -52,9 +52,9 @@ def default_config() -> config_dict.ConfigDict:
 
 
 def _make_turn_model(
-    xml_path: epath.Path, target_radius: float
+    xml_path: epath.Path, target_radius: float, assets: Dict[str, Any]
 ) -> mujoco.MjModel:
-  spec = mujoco.MjSpec.from_string(xml_path.read_text(), common.get_assets())
+  spec = mujoco.MjSpec.from_string(xml_path.read_text(), assets)
   target_site = None
   for site in spec.sites:
     if site.name == "target":
@@ -65,10 +65,10 @@ def _make_turn_model(
   return spec.compile()
 
 
-def _make_spin_model(xml_path: epath.Path) -> mujoco.MjModel:
-  model = mujoco.MjModel.from_xml_string(
-      xml_path.read_text(), common.get_assets()
-  )
+def _make_spin_model(
+    xml_path: epath.Path, assets: Dict[str, Any]
+) -> mujoco.MjModel:
+  model = mujoco.MjModel.from_xml_string(xml_path.read_text(), assets)
   model.site_rgba[model.site("target").id, 3] = 0
   model.site_rgba[model.site("tip").id, 3] = 0
   model.dof_damping[model.joint("hinge").id] = 0.03
@@ -90,7 +90,8 @@ class Spin(mjx_env.MjxEnv):
       )
 
     self._xml_path = _XML_PATH.as_posix()
-    self._mj_model = _make_spin_model(_XML_PATH)
+    self._model_assets = common.get_assets()
+    self._mj_model = _make_spin_model(_XML_PATH, self._model_assets)
     self._mj_model.opt.timestep = self.sim_dt
     self._mjx_model = mjx.put_model(self._mj_model)
     self._post_init()
@@ -214,7 +215,10 @@ class Turn(mjx_env.MjxEnv):
       )
 
     self._xml_path = _XML_PATH.as_posix()
-    self._mj_model = _make_turn_model(_XML_PATH, target_radius)
+    self._model_assets = common.get_assets()
+    self._mj_model = _make_turn_model(
+        _XML_PATH, target_radius, self._model_assets
+    )
     self._mj_model.opt.timestep = self.sim_dt
     self._mjx_model = mjx.put_model(self._mj_model)
     self._post_init()

--- a/mujoco_playground/_src/dm_control_suite/fish.py
+++ b/mujoco_playground/_src/dm_control_suite/fish.py
@@ -64,8 +64,9 @@ class Swim(mjx_env.MjxEnv):
       )
 
     self._xml_path = _XML_PATH.as_posix()
+    self._model_assets = common.get_assets()
     self._mj_model = mujoco.MjModel.from_xml_string(
-        _XML_PATH.read_text(), common.get_assets()
+        _XML_PATH.read_text(), self._model_assets
     )
     self._mj_model.opt.timestep = self.sim_dt
     self._mjx_model = mjx.put_model(self._mj_model)

--- a/mujoco_playground/_src/dm_control_suite/hopper.py
+++ b/mujoco_playground/_src/dm_control_suite/hopper.py
@@ -73,8 +73,9 @@ class Hopper(mjx_env.MjxEnv):
       ]
 
     self._xml_path = _XML_PATH.as_posix()
+    self._model_assets = common.get_assets()
     self._mj_model = mujoco.MjModel.from_xml_string(
-        _XML_PATH.read_text(), common.get_assets()
+        _XML_PATH.read_text(), self._model_assets
     )
     self._mj_model.opt.timestep = self.sim_dt
     self._mjx_model = mjx.put_model(self._mj_model)

--- a/mujoco_playground/_src/dm_control_suite/humanoid.py
+++ b/mujoco_playground/_src/dm_control_suite/humanoid.py
@@ -67,8 +67,9 @@ class Humanoid(mjx_env.MjxEnv):
       self._stand_or_move_reward = self._move_reward
 
     self._xml_path = _XML_PATH.as_posix()
+    self._model_assets = common.get_assets()
     self._mj_model = mujoco.MjModel.from_xml_string(
-        _XML_PATH.read_text(), common.get_assets()
+        _XML_PATH.read_text(), self._model_assets
     )
     self._mj_model.opt.timestep = self.sim_dt
     self._mjx_model = mjx.put_model(self._mj_model)

--- a/mujoco_playground/_src/dm_control_suite/pendulum.py
+++ b/mujoco_playground/_src/dm_control_suite/pendulum.py
@@ -57,8 +57,9 @@ class SwingUp(mjx_env.MjxEnv):
       )
 
     self._xml_path = _XML_PATH.as_posix()
+    self._model_assets = common.get_assets()
     self._mj_model = mujoco.MjModel.from_xml_string(
-        _XML_PATH.read_text(), common.get_assets()
+        _XML_PATH.read_text(), self._model_assets
     )
     self._mj_model.opt.timestep = self.sim_dt
     self._mjx_model = mjx.put_model(self._mj_model)

--- a/mujoco_playground/_src/dm_control_suite/point_mass.py
+++ b/mujoco_playground/_src/dm_control_suite/point_mass.py
@@ -54,8 +54,9 @@ class PointMass(mjx_env.MjxEnv):
       )
 
     self._xml_path = _XML_PATH.as_posix()
+    self._model_assets = common.get_assets()
     self._mj_model = mujoco.MjModel.from_xml_string(
-        _XML_PATH.read_text(), common.get_assets()
+        _XML_PATH.read_text(), self._model_assets
     )
     self._mj_model.opt.timestep = self.sim_dt
     self._mjx_model = mjx.put_model(self._mj_model)

--- a/mujoco_playground/_src/dm_control_suite/reacher.py
+++ b/mujoco_playground/_src/dm_control_suite/reacher.py
@@ -42,8 +42,10 @@ def default_config() -> config_dict.ConfigDict:
   )
 
 
-def _make_model(xml_path: epath.Path, target_size: float) -> mujoco.MjModel:
-  spec = mujoco.MjSpec.from_string(xml_path.read_text(), common.get_assets())
+def _make_model(
+    xml_path: epath.Path, target_size: float, assets: Dict[str, Any]
+) -> mujoco.MjModel:
+  spec = mujoco.MjSpec.from_string(xml_path.read_text(), assets)
   if mujoco.__version__ >= "3.3.0":
     target_body = spec.body("target")
   else:
@@ -70,7 +72,8 @@ class Reacher(mjx_env.MjxEnv):
 
     self._target_size = target_size
     self._xml_path = _XML_PATH.as_posix()
-    self._mj_model = _make_model(_XML_PATH, target_size)
+    self._model_assets = common.get_assets()
+    self._mj_model = _make_model(_XML_PATH, target_size, self._model_assets)
     self._mj_model.opt.timestep = self.sim_dt
     self._mjx_model = mjx.put_model(self._mj_model)
     self._post_init()

--- a/mujoco_playground/_src/dm_control_suite/swimmer.py
+++ b/mujoco_playground/_src/dm_control_suite/swimmer.py
@@ -125,8 +125,9 @@ class Swim(mjx_env.MjxEnv):
       )
 
     self._xml_path = _XML_PATH.as_posix()
+    self._model_assets = common.get_assets()
     self._mj_model = mujoco.MjModel.from_xml_string(
-        _make_model(self.xml_path, n_links), common.get_assets()
+        _make_model(self.xml_path, n_links), self._model_assets
     )
     self._mj_model.opt.timestep = self.sim_dt
     self._mjx_model = mjx.put_model(self._mj_model)

--- a/mujoco_playground/_src/dm_control_suite/walker.py
+++ b/mujoco_playground/_src/dm_control_suite/walker.py
@@ -67,8 +67,9 @@ class PlanarWalker(mjx_env.MjxEnv):
       self._get_reward = self._get_move_reward
 
     self._xml_path = _XML_PATH.as_posix()
+    self._model_assets = common.get_assets()
     self._mj_model = mujoco.MjModel.from_xml_string(
-        _XML_PATH.read_text(), common.get_assets()
+        _XML_PATH.read_text(), self._model_assets
     )
     self._mj_model.opt.timestep = self.sim_dt
     self._mjx_model = mjx.put_model(self._mj_model)

--- a/mujoco_playground/_src/locomotion/barkour/joystick.py
+++ b/mujoco_playground/_src/locomotion/barkour/joystick.py
@@ -117,7 +117,8 @@ class Joystick(mjx_env.MjxEnv):
     xml_path = mjx_env.MENAGERIE_PATH / "google_barkour_vb" / "scene_mjx.xml"
     self._xml_path = xml_path.as_posix()
     xml = epath.Path(xml_path).read_text()
-    mj_model = mujoco.MjModel.from_xml_string(xml, assets=get_assets())
+    self._model_assets = get_assets()
+    mj_model = mujoco.MjModel.from_xml_string(xml, assets=self._model_assets)
     mj_model.vis.global_.offwidth = 3840
     mj_model.vis.global_.offheight = 2160
     mj_model.dof_damping[6:] = 0.5239
@@ -451,7 +452,7 @@ class Joystick(mjx_env.MjxEnv):
 
   @property
   def xml_path(self) -> str:
-    raise self._xml_path
+    return self._xml_path
 
   @property
   def action_size(self) -> int:

--- a/mujoco_playground/_src/locomotion/berkeley_humanoid/base.py
+++ b/mujoco_playground/_src/locomotion/berkeley_humanoid/base.py
@@ -48,8 +48,9 @@ class BerkeleyHumanoidEnv(mjx_env.MjxEnv):
   ) -> None:
     super().__init__(config, config_overrides)
 
+    self._model_assets = get_assets()
     self._mj_model = mujoco.MjModel.from_xml_string(
-        epath.Path(xml_path).read_text(), assets=get_assets()
+        epath.Path(xml_path).read_text(), assets=self._model_assets
     )
     self._mj_model.opt.timestep = self.sim_dt
 

--- a/mujoco_playground/_src/locomotion/g1/base.py
+++ b/mujoco_playground/_src/locomotion/g1/base.py
@@ -47,8 +47,9 @@ class G1Env(mjx_env.MjxEnv):
   ) -> None:
     super().__init__(config, config_overrides)
 
+    self._model_assets = get_assets()
     self._mj_model = mujoco.MjModel.from_xml_string(
-        epath.Path(xml_path).read_text(), assets=get_assets()
+        epath.Path(xml_path).read_text(), assets=self._model_assets
     )
     self._mj_model.opt.timestep = self.sim_dt
 

--- a/mujoco_playground/_src/locomotion/go1/base.py
+++ b/mujoco_playground/_src/locomotion/go1/base.py
@@ -48,8 +48,9 @@ class Go1Env(mjx_env.MjxEnv):
   ) -> None:
     super().__init__(config, config_overrides)
 
+    self._model_assets = get_assets()
     self._mj_model = mujoco.MjModel.from_xml_string(
-        epath.Path(xml_path).read_text(), assets=get_assets()
+        epath.Path(xml_path).read_text(), assets=self._model_assets
     )
     self._mj_model.opt.timestep = self._config.sim_dt
 

--- a/mujoco_playground/_src/locomotion/h1/base.py
+++ b/mujoco_playground/_src/locomotion/h1/base.py
@@ -46,8 +46,9 @@ class H1Env(mjx_env.MjxEnv):
   ) -> None:
     super().__init__(config, config_overrides)
 
+    self._model_assets = get_assets()
     self._mj_model = mujoco.MjModel.from_xml_string(
-        epath.Path(xml_path).read_text(), assets=get_assets()
+        epath.Path(xml_path).read_text(), assets=self._model_assets
     )
     self._mj_model.opt.timestep = self._config.sim_dt
 

--- a/mujoco_playground/_src/locomotion/op3/base.py
+++ b/mujoco_playground/_src/locomotion/op3/base.py
@@ -47,8 +47,9 @@ class Op3Env(mjx_env.MjxEnv):
       config_overrides: Optional[Dict[str, Union[str, int, list[Any]]]] = None,
   ) -> None:
     super().__init__(config, config_overrides)
+    self._model_assets = get_assets()
     self._mj_model = mujoco.MjModel.from_xml_string(
-        epath.Path(xml_path).read_text(), assets=get_assets()
+        epath.Path(xml_path).read_text(), assets=self._model_assets
     )
     self._mj_model.opt.timestep = config.sim_dt
 

--- a/mujoco_playground/_src/locomotion/spot/base.py
+++ b/mujoco_playground/_src/locomotion/spot/base.py
@@ -47,8 +47,9 @@ class SpotEnv(mjx_env.MjxEnv):
       config_overrides: Optional[Dict[str, Union[str, int, list[Any]]]] = None,
   ) -> None:
     super().__init__(config, config_overrides)
+    self._model_assets = get_assets()
     self._mj_model = mujoco.MjModel.from_xml_string(
-        epath.Path(xml_path).read_text(), assets=get_assets()
+        epath.Path(xml_path).read_text(), assets=self._model_assets
     )
     self._mj_model.opt.timestep = config.sim_dt
 

--- a/mujoco_playground/_src/locomotion/t1/base.py
+++ b/mujoco_playground/_src/locomotion/t1/base.py
@@ -47,8 +47,9 @@ class T1Env(mjx_env.MjxEnv):
   ) -> None:
     super().__init__(config, config_overrides)
 
+    self._model_assets = get_assets()
     self._mj_model = mujoco.MjModel.from_xml_string(
-        epath.Path(xml_path).read_text(), assets=get_assets()
+        epath.Path(xml_path).read_text(), assets=self._model_assets
     )
     self._mj_model.opt.timestep = self.sim_dt
 

--- a/mujoco_playground/_src/manipulation/aloha/base.py
+++ b/mujoco_playground/_src/manipulation/aloha/base.py
@@ -51,8 +51,9 @@ class AlohaEnv(mjx_env.MjxEnv):
   ) -> None:
     super().__init__(config, config_overrides)
 
+    self._model_assets = get_assets()
     self._mj_model = mujoco.MjModel.from_xml_string(
-        epath.Path(xml_path).read_text(), assets=get_assets()
+        epath.Path(xml_path).read_text(), assets=self._model_assets
     )
     self._mj_model.opt.timestep = self._config.sim_dt
 

--- a/mujoco_playground/_src/manipulation/franka_emika_panda/pick_cartesian.py
+++ b/mujoco_playground/_src/manipulation/franka_emika_panda/pick_cartesian.py
@@ -105,10 +105,11 @@ class PandaPickCubeCartesian(pick.PandaPickCube):
         / 'mjx_single_cube_camera.xml'
     )
     self._xml_path = xml_path.as_posix()
+    self._model_assets = panda.get_assets()
 
     mj_model = self.modify_model(
         mujoco.MjModel.from_xml_string(
-            xml_path.read_text(), assets=panda.get_assets()
+            xml_path.read_text(), assets=self._model_assets
         )
     )
     mj_model.opt.timestep = config.sim_dt

--- a/mujoco_playground/_src/manipulation/franka_emika_panda_robotiq/panda_robotiq.py
+++ b/mujoco_playground/_src/manipulation/franka_emika_panda_robotiq/panda_robotiq.py
@@ -73,7 +73,8 @@ class PandaRobotiqBase(mjx_env.MjxEnv):
 
     self._xml_path = xml_path.as_posix()
     xml = xml_path.read_text()
-    mj_model = mujoco.MjModel.from_xml_string(xml, assets=get_assets())
+    self._model_assets = get_assets()
+    mj_model = mujoco.MjModel.from_xml_string(xml, assets=self._model_assets)
     mj_model.opt.timestep = self.sim_dt
 
     self._mj_model = mj_model
@@ -161,7 +162,7 @@ class PandaRobotiqBase(mjx_env.MjxEnv):
 
   @property
   def xml_path(self) -> str:
-    raise self._xml_path
+    return self._xml_path
 
   @property
   def action_size(self) -> int:

--- a/mujoco_playground/_src/manipulation/leap_hand/base.py
+++ b/mujoco_playground/_src/manipulation/leap_hand/base.py
@@ -49,8 +49,9 @@ class LeapHandEnv(mjx_env.MjxEnv):
       config_overrides: Optional[Dict[str, Union[str, int, list[Any]]]] = None,
   ) -> None:
     super().__init__(config, config_overrides)
+    self._model_assets = get_assets()
     self._mj_model = mujoco.MjModel.from_xml_string(
-        epath.Path(xml_path).read_text(), assets=get_assets()
+        epath.Path(xml_path).read_text(), assets=self._model_assets
     )
     self._mj_model.opt.timestep = self._config.sim_dt
 

--- a/mujoco_playground/_src/mjx_env.py
+++ b/mujoco_playground/_src/mjx_env.py
@@ -273,6 +273,16 @@ class MjxEnv(abc.ABC):
       return jax.tree_util.tree_map(lambda x: x.shape, obs)
     return obs.shape[-1]
 
+  @property
+  def model_assets(self) -> Dict[str, Any]:
+    """Dictionary of model assets to use with MjModel.from_xml_path"""
+    if hasattr(self, "_model_assets"):
+      return self._model_assets
+    raise NotImplementedError(
+        "_model_assets not defined for this environment"
+        "see cartpole.py for an example."
+    )
+
   def render(
       self,
       trajectory: List[State],


### PR DESCRIPTION
Re: https://github.com/google-deepmind/mujoco_playground/issues/154

Tested by looping through registry.ALL_ENVS and initializing rscope.brax.BraxRolloutSaver, which requires the model_assets property.