### PR TITLE
Fix #192.

### DIFF
--- a/learning/train_jax_ppo.py
+++ b/learning/train_jax_ppo.py
@@ -285,7 +285,7 @@ def main(argv):
 
   # Initialize Weights & Biases if required
   if _USE_WANDB.value and not _PLAY_ONLY.value:
-    wandb.init(project="mjxrl", entity="dextrm", name=exp_name)
+    wandb.init(project="mjxrl", name=exp_name)
     wandb.config.update(env_cfg.to_dict())
     wandb.config.update({"env_name": _ENV_NAME.value})
 

--- a/learning/train_rsl_rl.py
+++ b/learning/train_rsl_rl.py
@@ -131,7 +131,7 @@ def main(argv):
   # Initialize Weights & Biases if required
   if _USE_WANDB.value and not _PLAY_ONLY.value:
     wandb.tensorboard.patch(root_logdir=logdir)
-    wandb.init(project="mjxrl", entity="dextrm", name=exp_name)
+    wandb.init(project="mjxrl", name=exp_name)
     wandb.config.update(env_cfg.to_dict())
     wandb.config.update({"env_name": _ENV_NAME.value})
 


### PR DESCRIPTION
This PR removes the hardcoded `entity` from the `wandb.init` call, allowing users to log experiments to their own accounts.