### PR TITLE
Allow Wrapper.render to accept **kwargs

### DIFF
--- a/mujoco_playground/_src/wrapper.py
+++ b/mujoco_playground/_src/wrapper.py
@@ -78,10 +78,18 @@ class Wrapper(mjx_env.MjxEnv):
       modify_scene_fns: Optional[
           Sequence[Callable[[mujoco.MjvScene], None]]
       ] = None,
+      **kwargs,
   ) -> Sequence[np.ndarray]:
     return self.env.render(
-        trajectory, height, width, camera, scene_option, modify_scene_fns
+        trajectory,
+        height=height,
+        width=width,
+        camera=camera,
+        scene_option=scene_option,
+        modify_scene_fns=modify_scene_fns,
+        **kwargs,
     )
+
 
 
 def wrap_for_brax_training(


### PR DESCRIPTION
This enables custom environments to pass additional render arguments through the wrapper chain. The kwargs are forwarded to the underlying env.render() call.

Closes #258