### PR TITLE
fix: env name typo

### DIFF
--- a/mujoco_playground/config/dm_control_suite_params.py
+++ b/mujoco_playground/config/dm_control_suite_params.py
@@ -53,7 +53,7 @@ def brax_ppo_config(
     rl_config.num_timesteps = 100_000_000
   elif env_name == "FingerSpin":
     rl_config.discounting = 0.95
-  elif env_name == "PendulumSwingUp":
+  elif env_name == "PendulumSwingup":
     rl_config.action_repeat = 4
     rl_config.num_updates_per_batch = 4
 


### PR DESCRIPTION
Fixed a typo in the ppo config loader for DM Control Suite that prevented it from loading the correct config for the Pendulum Swingup task: `"PendulumSwingUp"` --> `"PendulumSwingup"`. Without these tuned parameters, it is unable to reach high reward.