### PR TITLE
Fix redundant HField upload in render_array

### DIFF
--- a/mujoco_playground/_src/mjx_env.py
+++ b/mujoco_playground/_src/mjx_env.py
@@ -328,12 +328,11 @@ def render_array(
     hfield_data: Optional[jax.Array] = None,
 ):
   """Renders a trajectory as an array of images."""
-  renderer = mujoco.Renderer(mj_model, height=height, width=width)
-  camera = camera if camera is not None else -1
-
   if hfield_data is not None:
     mj_model.hfield_data = hfield_data.reshape(mj_model.hfield_data.shape)
-    mujoco.mjr_uploadHField(mj_model, renderer._mjr_context, 0)
+
+  renderer = mujoco.Renderer(mj_model, height=height, width=width)
+  camera = camera if camera is not None else -1
 
   def get_image(state, modify_scn_fn=None) -> np.ndarray:
     d = mujoco.MjData(mj_model)


### PR DESCRIPTION
This PR removes a redundant 'mjr_uploadHField' call in the 'render_array' function.
Currently, render_array updates the model's hfield data and then explicitly calls 'mjr_uploadHField' after initializing the Renderer.
However, upon inspecting the underlying C implementation in 'src/render/render_context.c' from mujoco, the Renderer initialization (via ‘mjr_makeContext’) inherently calls ‘makeHField’ and ‘mjr_uploadHField’, which uploads all assets including height fields to the GPU.
I performed a simple manual visual comparison comparing the original logic vs. this optimized logic. Both methods correctly render dynamically updated bumpy terrain.
<img width="470" height="334" alt="b2298f5d-652f-429d-b4bf-e3b91c46b2a9" src="https://github.com/user-attachments/assets/483172c5-477a-4d99-b5a8-45c35d81657b" />
<img width="395" height="271" alt="1f1bbaa3-880d-464f-89e2-f89f0935a0b3" src="https://github.com/user-attachments/assets/7d4c6e98-4c18-4749-b633-2fafd7ee5dad" />