### PR TITLE
Preserve terminal observation in BraxAutoResetWrapper for truncation bootstrap

### DIFF
--- a/mujoco_playground/_src/wrapper.py
+++ b/mujoco_playground/_src/wrapper.py
@@ -153,6 +153,14 @@ class BraxAutoResetWrapper(Wrapper):
     state.info[f'{self._info_key}_done_count'] = jp.zeros(
         key.shape[:-1], dtype=int
     )
+    # Seed the final-obs slot with the initial observation so the info dict
+    # has the same key set on reset and on step. JAX traced state (e.g.
+    # EpisodeWrapper, VmapWrapper) requires consistent tree structure across
+    # all transitions; an asymmetric info would raise a Dict key mismatch on
+    # the first stepped transition. No semantic meaning on the very first
+    # observation (no episode has terminated yet); learners should gate on
+    # state.info['truncation'] before using this field.
+    state.info[f'{self._info_key}_final_obs'] = state.obs
     return state
 
   def step(self, state: mjx_env.State, action: jax.Array) -> mjx_env.State:

--- a/mujoco_playground/_src/wrapper.py
+++ b/mujoco_playground/_src/wrapper.py
@@ -185,10 +185,21 @@ class BraxAutoResetWrapper(Wrapper):
         done = jp.reshape(done, [x.shape[0]] + [1] * (len(x.shape) - 1))
       return jp.where(done, x, y)
 
+    # Preserve the pre-reset observation BEFORE the where_done replacement
+    # below clobbers it. Downstream RL learners need this terminal observation
+    # to compute the correct value-bootstrap target on truncation:
+    #   target = r_t + gamma * V(s_{t+1})
+    # where s_{t+1} is the observation the agent would have seen next had the
+    # episode not been truncated, not the reset observation. Without this
+    # field, every actor-critic implementation on Playground silently
+    # bootstraps on V(s_reset). See issue #305.
+    final_obs = state.obs
+
     data = jax.tree.map(where_done, reset_data, state.data)
     obs = jax.tree.map(where_done, reset_obs, state.obs)
 
     next_info = state.info
+    next_info[f'{self._info_key}_final_obs'] = final_obs
     done_count_key = f'{self._info_key}_done_count'
     if self._full_reset and reset_state:
       next_info = jax.tree.map(where_done, reset_state.info, state.info)

--- a/mujoco_playground/_src/wrapper_test.py
+++ b/mujoco_playground/_src/wrapper_test.py
@@ -87,6 +87,22 @@ class WrapperTest(parameterized.TestCase):
       self.assertEqual(state.info['AutoResetWrapper_preserve_info'], 2)
       expected_other_info = 1 if full_reset else 2
       self.assertEqual(state.info['other_info'], expected_other_info)
+      # Regression for #305: the pre-reset (terminal) observation must be
+      # stashed in info so downstream RL learners can compute the correct
+      # value-bootstrap target on truncation.
+      self.assertIn('AutoResetWrapper_final_obs', state.info)
+      self.assertEqual(
+          state.info['AutoResetWrapper_final_obs'].shape, state.obs.shape
+      )
+      # On a done step, state.obs has been replaced by the reset observation;
+      # final_obs must hold the terminal observation, which differs.
+      self.assertFalse(
+          np.allclose(
+              np.asarray(state.info['AutoResetWrapper_final_obs']),
+              np.asarray(state.obs),
+              atol=1e-6,
+          )
+      )
 
   @parameterized.named_parameters(
       ('full_reset', True),


### PR DESCRIPTION
## Summary

Fixes #305.

`BraxAutoResetWrapper.step` in `mujoco_playground/_src/wrapper.py` overwrites `state.obs` with the reset observation on `state.done` without preserving the pre-reset (terminal) observation. Downstream actor-critic learners therefore have no way to compute the correct value-bootstrap target on truncation:

```
target = r_t + gamma * V(s_{t+1})
```

where `s_{t+1}` is the observation the agent *would have seen next* had the episode not been truncated, not the reset observation. The result is that every PPO/SAC implementation built on Playground silently bootstraps on `V(s_reset)` at every truncation. The bias grows with episode length and gamma and is particularly bad on locomotion tasks where the reset pose is very different from the late-episode state. @YannBerthelot's issue write-up covers the math and the comparison to brax upstream / Gymnasium thoroughly.

## Change

`mujoco_playground/_src/wrapper.py`: stash `state.obs` (the pre-reset observation returned by the wrapped env's step) under `info['AutoResetWrapper_final_obs']` before the `where_done` mask replaces it. The new field is set on every step; learners can combine it with the existing `info['truncation']` signal to apply the correct bootstrap on truncation only.

This matches the convention already used by Gymnasium's `info['final_observation']` (since v0.26).

The fix is the same shape as the proposal in #305 and credits @YannBerthelot in the commit message.

## Test plan

Extended `WrapperTest.test_auto_reset_wrapper` in `mujoco_playground/_src/wrapper_test.py` so the existing `(full_reset, cache_reset)` parameterized cases additionally assert:

- [x] `info['AutoResetWrapper_final_obs']` is present after a done step.
- [x] Its shape matches `state.obs.shape`.
- [x] On a done step (where `state.obs` has been replaced by the reset observation), `final_obs` differs from `state.obs`; confirming the terminal observation, not the reset, was stashed.

- [ ] **Could not run pytest locally**: mujoco_playground's full install needs JAX + brax + MuJoCo + dm_control_suite. I am relying on CI to run the wrapper test plus the rest of `_src/` tests.

## CLA

I previously signed the Google CLA via dparikh79 for google-deepmind/mujoco, google-deepmind/mujoco_menagerie, and google-deepmind/dm_control. The umbrella should cover this contribution; if the CLA bot reports otherwise, happy to re-sign.

## AI Assistance Disclosure

Implementation and the regression test were drafted with Claude assistance, against @YannBerthelot's rigorous bug analysis in #305. I reviewed every changed line, traced the call into `BraxAutoResetWrapper.step` to confirm the where_done mask and `state.replace` semantics, and confirmed the test extends the existing parameterized assertions without breaking them. I am the human contributor accountable for this PR.

cc: @YannBerthelot
