### PR TITLE
List all supported sigmoid types in tolerance docstring

### DIFF
--- a/mujoco_playground/_src/reward.py
+++ b/mujoco_playground/_src/reward.py
@@ -99,7 +99,8 @@ def tolerance(
       all values of `x` outside of `bounds`. * If `margin > 0` then the output
       will decrease sigmoidally with increasing distance from the nearest bound.
     sigmoid: String, choice of sigmoid type. Valid values are: 'gaussian',
-      'linear', 'hyperbolic', 'long_tail', 'cosine', 'tanh_squared'.
+      'hyperbolic', 'long_tail', 'reciprocal', 'cosine', 'linear', 'quadratic',
+      'tanh_squared'.
     value_at_margin: A float between 0 and 1 specifying the output value when
       the distance from `x` to the nearest bound is equal to `margin`. Ignored
       if `margin == 0`.


### PR DESCRIPTION
The `sigmoid` argument docstring for `reward.tolerance` lists six valid values:

```
'gaussian', 'linear', 'hyperbolic', 'long_tail', 'cosine', 'tanh_squared'
```

but `_sigmoids` actually implements eight. `'reciprocal'` and `'quadratic'` are fully functional but missing from the docstring, so a caller reading the docs has no way to know they exist (and might assume passing them raises the "Unknown sigmoid type" error).

Confirmed both work on current main:

```python
from mujoco_playground._src import reward
import jax.numpy as jp
reward.tolerance(jp.array(0.5), margin=1.0, sigmoid='reciprocal')  # 0.1818
reward.tolerance(jp.array(0.5), margin=1.0, sigmoid='quadratic')   # 0.7750
```

This lists all eight types in the order `_sigmoids` handles them. Docstring only, no behavior change.