### PR TITLE
Forward **kwargs through Wrapper.render to the wrapped env

### DIFF
--- a/mujoco_playground/_src/wrapper.py
+++ b/mujoco_playground/_src/wrapper.py
@@ -77,9 +77,16 @@ class Wrapper(mjx_env.MjxEnv):
       modify_scene_fns: Optional[
           Sequence[Callable[[mujoco.MjvScene], None]]
       ] = None,
+      **kwargs,
   ) -> Sequence[np.ndarray]:
     return self.env.render(
-        trajectory, height, width, camera, scene_option, modify_scene_fns
+        trajectory,
+        height=height,
+        width=width,
+        camera=camera,
+        scene_option=scene_option,
+        modify_scene_fns=modify_scene_fns,
+        **kwargs,
     )
 
 

--- a/mujoco_playground/_src/wrapper_test.py
+++ b/mujoco_playground/_src/wrapper_test.py
@@ -131,6 +131,26 @@ class WrapperTest(parameterized.TestCase):
     else:
       np.testing.assert_allclose(state.obs, first_obs, rtol=1e-6)
 
+  def test_render_forwards_kwargs(self):
+    """Tests that Wrapper.render forwards extra kwargs to the wrapped env."""
+
+    class RecordingEnv:
+
+      def __init__(self):
+        self.received_kwargs = None
+
+      def render(self, trajectory, height=240, width=320, camera=None,
+                 scene_option=None, modify_scene_fns=None, **kwargs):
+        del trajectory, height, width, camera, scene_option, modify_scene_fns
+        self.received_kwargs = kwargs
+        return []
+
+    inner = RecordingEnv()
+    wrapped = wrapper.Wrapper(inner)
+    wrapped.render([], hfield_data=123, foo='bar')
+
+    self.assertEqual(inner.received_kwargs, {'hfield_data': 123, 'foo': 'bar'})
+
   def test_domain_randomization_wrapper(self):
     def randomization_fn(model, rng):
       @jax.vmap


### PR DESCRIPTION
## Summary

`Wrapper.render` (the base wrapper in `mujoco_playground/_src/wrapper.py`)
forwarded only a fixed set of positional arguments to `self.env.render`, so any
extra render keyword arguments defined by a custom environment were silently
dropped. This makes such kwargs reach the wrapped environment.

Fixes #258.

## What changed

- `Wrapper.render` now accepts and forwards `**kwargs` to `self.env.render`.
- Forwarding switched to keyword arguments for the existing named parameters,
  for clarity at the call site.
- Added `WrapperTest.test_render_forwards_kwargs`, a small regression test using
  a recording env that asserts extra kwargs are passed through.

## Backward compatibility

Fully backward compatible: existing call sites pass the same named arguments,
and envs whose `render` does not accept extra kwargs are unaffected because no
extra kwargs are added by existing callers.
