### PR TITLE
fix: align Warp dependency with mujoco-mjx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,8 @@ dependencies = [
     "lxml",
     "mediapy",
     "ml_collections",
-    "mujoco-mjx>=3.6.0",
+    "mujoco-mjx[warp]>=3.6.0",
     "mujoco>=3.6.0",
-    "warp-lang>=1.11",
     "orbax-checkpoint>=0.11.22",
     "tqdm",
 ]


### PR DESCRIPTION
## Summary

- Depend on `mujoco-mjx[warp]` so MJX selects its compatible Warp version.
- Remove Playground's independent `warp-lang` lower bound.

Fixes #333

## Why

`mujoco-mjx` owns the MJX/Warp compatibility boundary. Its 3.10.0 release pins `warp-lang` 1.13.0, while Playground's separate `warp-lang>=1.11` requirement allowed 1.14.0 and 1.15.0, which fail while loading `CartpoleBalance` at `GraphMode.WARP`.

## Validation

- [x] Python 3.11.15 clean install resolved `mujoco-mjx` 3.10.0 with `warp-lang` 1.13.0; `CartpoleBalance` loaded successfully.
- [x] Python 3.12.13 clean install resolved `mujoco-mjx` 3.10.0 with `warp-lang` 1.13.0; `CartpoleBalance` loaded successfully.
- [x] `pytest -n auto mujoco_playground/_src/` — 61 passed on Python 3.12.13.
- [x] `git diff --check`

## Notes for reviewers

- `uv.lock` is unchanged: it already requires a broad refresh, and CI installs the editable test extra directly rather than consuming the lockfile.
- The configured pre-commit hooks only target Python files; running them across current `main` reformats unrelated Python files, so those baseline-only changes were discarded.
