### PR TITLE
Prevent NaN reward propagation in Humanoid tasks

### DIFF
--- a/mujoco_playground/_src/dm_control_suite/dm_control_suite_test.py
+++ b/mujoco_playground/_src/dm_control_suite/dm_control_suite_test.py
@@ -14,12 +14,15 @@
 
 """Tests for the DM Control Suite."""
 
+from unittest import mock
+
 from absl.testing import absltest
 from absl.testing import parameterized
 import jax
 from jax import numpy as jp
 
 from mujoco_playground._src import dm_control_suite
+from mujoco_playground._src import mjx_env
 
 
 class TestSuite(parameterized.TestCase):
@@ -57,6 +60,23 @@ class TestSuite(parameterized.TestCase):
     warn_overflow = int(mjx_model.opt._impl.warn_overflow)
     self.assertEqual(warn_overflow & int(mjw.OverflowType.ITERATIONS), 0)
     self.assertEqual(warn_overflow & int(mjw.OverflowType.LS_ITERATIONS), 0)
+
+  @parameterized.parameters("qpos", "qvel")
+  def test_humanoid_nan_state_zeroes_reward(self, invalid_field: str) -> None:
+    env = dm_control_suite.load(
+        "HumanoidStand", config_overrides={"impl": "jax"}
+    )
+    state = jax.jit(env.reset)(jax.random.PRNGKey(42))
+    invalid_data = state.data.replace(
+        **{invalid_field: getattr(state.data, invalid_field).at[0].set(jp.nan)},
+        xpos=state.data.xpos.at[env.mj_model.body("head").id, -1].set(jp.nan),
+    )
+
+    with mock.patch.object(mjx_env, "step", return_value=invalid_data):
+      state = env.step(state, jp.zeros(env.action_size))
+
+    self.assertEqual(float(state.done), 1.0)
+    self.assertEqual(float(state.reward), 0.0)
 
 
 if __name__ == "__main__":

--- a/mujoco_playground/_src/dm_control_suite/dm_control_suite_test.py
+++ b/mujoco_playground/_src/dm_control_suite/dm_control_suite_test.py
@@ -14,12 +14,15 @@
 # ==============================================================================
 """Tests for the DM Control Suite."""
 
+from unittest import mock
+
 from absl.testing import absltest
 from absl.testing import parameterized
 import jax
 from jax import numpy as jp
 
 from mujoco_playground._src import dm_control_suite
+from mujoco_playground._src import mjx_env
 
 
 class TestSuite(parameterized.TestCase):
@@ -36,6 +39,22 @@ class TestSuite(parameterized.TestCase):
     self.assertIsNotNone(state)
     self.assertEqual(state.obs.shape[0], env.observation_size)
     self.assertFalse(jp.isnan(state.data.qpos).any())
+
+  def test_humanoid_nan_state_zeroes_reward(self) -> None:
+    env = dm_control_suite.load(
+        "HumanoidStand", config_overrides={"impl": "jax"}
+    )
+    state = env.reset(jax.random.PRNGKey(42))
+    invalid_data = state.data.replace(
+        qpos=state.data.qpos.at[0].set(jp.nan),
+        xpos=state.data.xpos.at[env.mj_model.body("head").id, -1].set(jp.nan),
+    )
+
+    with mock.patch.object(mjx_env, "step", return_value=invalid_data):
+      state = env.step(state, jp.zeros(env.action_size))
+
+    self.assertEqual(float(state.done), 1.0)
+    self.assertEqual(float(state.reward), 0.0)
 
 
 if __name__ == "__main__":

--- a/mujoco_playground/_src/dm_control_suite/humanoid.py
+++ b/mujoco_playground/_src/dm_control_suite/humanoid.py
@@ -116,8 +116,9 @@ class Humanoid(mjx_env.MjxEnv):
     data = mjx_env.step(self.mjx_model, state.data, action, self.n_substeps)
     reward = self._get_reward(data, action, state.info, state.metrics)  # pylint: disable=redefined-outer-name
     obs = self._get_obs(data, state.info)
-    done = jp.isnan(data.qpos).any() | jp.isnan(data.qvel).any()
-    done = done.astype(float)
+    invalid_state = jp.isnan(data.qpos).any() | jp.isnan(data.qvel).any()
+    reward = jp.where(invalid_state, jp.zeros_like(reward), reward)
+    done = invalid_state.astype(float)
     return mjx_env.State(data, obs, reward, done, state.metrics, state.info)
 
   def _get_obs(self, data: mjx.Data, info: dict[str, Any]) -> jax.Array:

--- a/mujoco_playground/_src/dm_control_suite/humanoid.py
+++ b/mujoco_playground/_src/dm_control_suite/humanoid.py
@@ -118,8 +118,9 @@ class Humanoid(mjx_env.MjxEnv):
     data = mjx_env.step(self.mjx_model, state.data, action, self.n_substeps)
     reward = self._get_reward(data, action, state.info, state.metrics)  # pylint: disable=redefined-outer-name
     obs = self._get_obs(data, state.info)
-    done = jp.isnan(data.qpos).any() | jp.isnan(data.qvel).any()
-    done = done.astype(float)
+    invalid_state = jp.isnan(data.qpos).any() | jp.isnan(data.qvel).any()
+    reward = jp.where(invalid_state, jp.zeros_like(reward), reward)
+    done = invalid_state.astype(float)
     return mjx_env.State(data, obs, reward, done, state.metrics, state.info)
 
   def _get_obs(self, data: mjx.Data, info: dict[str, Any]) -> jax.Array:


### PR DESCRIPTION
Prevent NaN physics states from returning a NaN learner-facing reward in Humanoid tasks. Keep the existing termination condition and use `jp.where` to select a zero reward for invalid states.

Rebased onto upstream `main` at `4057c147714b6ac09b395377f1a1724bbeacc4d3`, preserving both newer Warp overflow-warning tests. The regression test now covers NaNs in either `qpos` or `qvel`.

## Validation

`JAX_PLATFORMS=cpu python -m pytest -q mujoco_playground/_src/dm_control_suite/dm_control_suite_test.py -k 'Humanoid or humanoid'`

5 passed: two invalid-state regressions and the existing Humanoid stand, walk, and run smoke tests. Both regressions fail on unpatched `main` with `nan != 0.0`.

`git diff --check` passes. Ruff reports the same seven pre-existing findings in the two changed files, with no additional findings. The full suite and GPU execution were not run.

Fixes #240.
