### PR TITLE
Return current observations from the RSL-RL wrapper

### DIFF
--- a/mujoco_playground/_src/wrapper_torch.py
+++ b/mujoco_playground/_src/wrapper_torch.py
@@ -202,10 +202,7 @@ class RSLRLBraxWrapper(VecEnv):  # pyrefly: ignore[invalid-inheritance]
     )  # pyrefly: ignore[not-callable]
     return obs, reward, done, info_ret
 
-  def reset(self):
-    # todo add random init like in collab examples?
-    self.env_state = self.reset_fn(self.key_reset)
-
+  def _current_observations(self):
     if self.asymmetric_obs:
       obs = _jax_to_torch(self.env_state.obs["state"])
       critic_obs = _jax_to_torch(self.env_state.obs["privileged_state"])
@@ -217,8 +214,15 @@ class RSLRLBraxWrapper(VecEnv):  # pyrefly: ignore[invalid-inheritance]
         obs, batch_size=[self.num_envs]
     )  # pyrefly: ignore[not-callable]
 
+  def reset(self):
+    # todo add random init like in collab examples?
+    self.env_state = self.reset_fn(self.key_reset)
+    return self._current_observations()
+
   def get_observations(self):
-    return self.reset()
+    if self.env_state is None:
+      return self.reset()
+    return self._current_observations()
 
   def render(self, mode="human"):  # pylint: disable=unused-argument
     if self.render_callback is not None:

--- a/mujoco_playground/_src/wrapper_torch_test.py
+++ b/mujoco_playground/_src/wrapper_torch_test.py
@@ -1,0 +1,52 @@
+# Copyright 2025 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the Torch/RSL-RL wrapper."""
+
+from unittest import mock
+
+from absl.testing import absltest
+
+from mujoco_playground._src import wrapper_torch
+
+
+class RSLRLBraxWrapperTest(absltest.TestCase):
+
+  def test_get_observations_does_not_reset_initialized_env(self):
+    env = object.__new__(wrapper_torch.RSLRLBraxWrapper)
+    env.env_state = object()
+    expected_obs = object()
+    env._current_observations = mock.Mock(return_value=expected_obs)
+    env.reset = mock.Mock()
+
+    obs = env.get_observations()
+
+    self.assertIs(obs, expected_obs)
+    env.reset.assert_not_called()
+    env._current_observations.assert_called_once_with()
+
+  def test_get_observations_initializes_uninitialized_env(self):
+    env = object.__new__(wrapper_torch.RSLRLBraxWrapper)
+    env.env_state = None
+    expected_obs = object()
+    env.reset = mock.Mock(return_value=expected_obs)
+
+    obs = env.get_observations()
+
+    self.assertIs(obs, expected_obs)
+    env.reset.assert_called_once_with()
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
## Summary

RSL-RL's `VecEnv.get_observations()` contract is to return the current observations. `RSLRLBraxWrapper.get_observations()` currently delegates directly to `reset()`, so querying observations resets every wrapped environment.

This matters because RSL-RL queries observations when constructing `OnPolicyRunner` and again at the start of `learn()`. With the current wrapper, the second query resets the environments again immediately before rollout.

This change:

- extracts the existing observation conversion into `_current_observations()`;
- preserves initialization by calling `reset()` when `env_state` is still `None`;
- returns observations from the existing `env_state` on subsequent `get_observations()` calls;
- keeps explicit `reset()` behavior unchanged.

RSL-RL references:
- `VecEnv.get_observations()`: https://github.com/leggedrobotics/rsl_rl/blob/main/rsl_rl/env/vec_env.py
- `OnPolicyRunner` observation queries: https://github.com/leggedrobotics/rsl_rl/blob/main/rsl_rl/runners/on_policy_runner.py

## Validation

- Added a regression test verifying that `get_observations()` does not call `reset()` once the environment is initialized.
- Added a complementary test verifying that an uninitialized wrapper still initializes through `reset()`.
- Audited the final branch diff: 2 files, +61/-5 lines, with no unrelated changes.
- Squashed to one focused commit: `522453f80c66e8099419fcd1c3e85d4778fd8496`.
- Branch is based on current upstream `main` at `e74217bb89c77a74ba02e4789263991864375799`.
- Full tests were not run locally in this environment. The focused regression tests are included for upstream CI validation.
