### PR TITLE
Fix G1 RSL-RL config to use the registered environment name

### DIFF
--- a/mujoco_playground/_src/locomotion/locomotion_test.py
+++ b/mujoco_playground/_src/locomotion/locomotion_test.py
@@ -19,6 +19,7 @@ import jax
 import jax.numpy as jp
 
 from mujoco_playground._src import locomotion
+from mujoco_playground.config import locomotion_params
 
 
 class TestSuite(parameterized.TestCase):
@@ -37,6 +38,12 @@ class TestSuite(parameterized.TestCase):
     obs_shape = obs_shape[0] if isinstance(obs_shape, tuple) else obs_shape
     self.assertEqual(obs_shape, env.observation_size)
     self.assertFalse(jp.isnan(state.data.qpos).any())
+
+  def test_g1_rsl_config_uses_tuned_iteration_count(self) -> None:
+    env_name = "G1JoystickFlatTerrain"
+    self.assertIn(env_name, locomotion.ALL_ENVS)
+    config = locomotion_params.rsl_rl_config(env_name)
+    self.assertEqual(config.max_iterations, 1000)
 
 
 if __name__ == "__main__":

--- a/mujoco_playground/config/locomotion_params.py
+++ b/mujoco_playground/config/locomotion_params.py
@@ -215,7 +215,7 @@ def rsl_rl_config(
   if env_name in (
       "Go1Getup",
       "BerkeleyHumanoidJoystickFlatTerrain",
-      "G1Joystick",
+      "G1JoystickFlatTerrain",
       "Go1JoystickFlatTerrain",
   ):
     rl_config.max_iterations = 1000


### PR DESCRIPTION
## Summary

`rsl_rl_config()` applies a tuned `max_iterations=1000` schedule to several locomotion tasks, but the G1 entry is currently `G1Joystick`, which is not a registered MuJoCo Playground environment. The registered flat-terrain task is `G1JoystickFlatTerrain`, so that task misses the intended RSL-RL schedule and keeps the default `max_iterations=100000`.

This change:

- replaces the stale `G1Joystick` config key with the registered `G1JoystickFlatTerrain` name;
- leaves the existing RSL-RL hyperparameters unchanged;
- adds a regression test that verifies the environment is registered and receives `max_iterations=1000`.

## Validation

- Audited the final branch diff: 2 files, +8/-1 lines, with no unrelated changes.
- Squashed to one focused commit: `76f5e8887445b4921b1ba91af50722ba6bcb4e66`.
- Branch is based on current upstream `main` at `e74217bb89c77a74ba02e4789263991864375799`.
- Full tests were not run locally in this environment. The added regression test is included for upstream CI validation.
