### PR TITLE
feat(rsl-rl): support DM Control Suite environments

### DIFF
--- a/learning/train_rsl_rl.py
+++ b/learning/train_rsl_rl.py
@@ -33,6 +33,7 @@ import warp as wp
 from mujoco_playground import registry
 from mujoco_playground import wrapper_torch
 import mujoco_playground
+from mujoco_playground.config import dm_control_suite_params
 from mujoco_playground.config import locomotion_params
 from mujoco_playground.config import manipulation_params
 
@@ -100,6 +101,8 @@ def get_rl_config(env_name: str) -> config_dict.ConfigDict:
     return manipulation_params.rsl_rl_config(env_name)
   elif env_name in registry.locomotion._envs:
     return locomotion_params.rsl_rl_config(env_name)
+  elif env_name in registry.dm_control_suite._envs:
+    return dm_control_suite_params.rsl_rl_config(env_name)
   else:
     raise ValueError(f"No RL config for {env_name}")
 

--- a/mujoco_playground/_src/dm_control_suite/dm_control_suite_params_test.py
+++ b/mujoco_playground/_src/dm_control_suite/dm_control_suite_params_test.py
@@ -1,0 +1,53 @@
+# Copyright 2026 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for DM Control Suite training configs."""
+
+from absl.testing import absltest
+
+from mujoco_playground.config import dm_control_suite_params
+
+
+class DmControlSuiteParamsTest(absltest.TestCase):
+
+  def test_rsl_rl_config_reuses_brax_ppo_hyperparameters(self):
+    for env_name in ("CartpoleBalance", "BallInCup", "FingerSpin"):
+      with self.subTest(env_name=env_name):
+        brax_config = dm_control_suite_params.brax_ppo_config(env_name)
+        rsl_config = dm_control_suite_params.rsl_rl_config(env_name)
+
+        self.assertEqual(
+            rsl_config.algorithm.learning_rate, brax_config.learning_rate
+        )
+        self.assertEqual(rsl_config.algorithm.gamma, brax_config.discounting)
+        self.assertEqual(
+            rsl_config.algorithm.entropy_coef, brax_config.entropy_cost
+        )
+        self.assertEqual(rsl_config.num_steps_per_env, brax_config.unroll_length)
+
+  def test_rsl_rl_config_has_required_runner_fields(self):
+    config = dm_control_suite_params.rsl_rl_config("CartpoleBalance")
+
+    self.assertEqual(config.runner_class_name, "OnPolicyRunner")
+    self.assertEqual(config.policy.class_name, "ActorCritic")
+    self.assertEqual(config.algorithm.class_name, "PPO")
+    self.assertGreater(config.max_iterations, 0)
+
+  def test_rsl_rl_config_rejects_unknown_environment(self):
+    with self.assertRaisesRegex(ValueError, "not found in default configs"):
+      dm_control_suite_params.rsl_rl_config("NotAnEnvironment")
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/mujoco_playground/config/dm_control_suite_params.py
+++ b/mujoco_playground/config/dm_control_suite_params.py
@@ -150,3 +150,47 @@ def brax_sac_config(
     rl_config.num_timesteps = 10_000_000
 
   return rl_config
+
+
+def rsl_rl_config(
+    env_name: str, unused_impl: Optional[str] = None
+) -> config_dict.ConfigDict:
+  """Returns a baseline RSL-RL PPO config for the given environment."""
+  brax_config = brax_ppo_config(env_name)
+
+  return config_dict.create(
+      seed=1,
+      runner_class_name="OnPolicyRunner",
+      policy=config_dict.create(
+          init_noise_std=1.0,
+          actor_hidden_dims=[512, 256, 128],
+          critic_hidden_dims=[512, 256, 128],
+          activation="elu",
+          class_name="ActorCritic",
+      ),
+      algorithm=config_dict.create(
+          class_name="PPO",
+          value_loss_coef=1.0,
+          use_clipped_value_loss=True,
+          clip_param=0.2,
+          entropy_coef=brax_config.entropy_cost,
+          num_learning_epochs=5,
+          num_mini_batches=4,
+          learning_rate=brax_config.learning_rate,
+          schedule="fixed",
+          gamma=brax_config.discounting,
+          lam=0.95,
+          desired_kl=0.01,
+          max_grad_norm=1.0,
+      ),
+      num_steps_per_env=brax_config.unroll_length,
+      max_iterations=1000,
+      empirical_normalization=True,
+      save_interval=50,
+      experiment_name="test",
+      run_name="",
+      resume=False,
+      load_run="-1",
+      checkpoint=-1,
+      resume_path=None,
+  )


### PR DESCRIPTION
Fixes #111

## Summary

- add a baseline RSL-RL PPO config for DeepMind Control Suite environments
- reuse the existing DM Control Brax PPO learning rate, discount, entropy, and rollout-length settings where they map directly to RSL-RL
- route DM Control environments through `train_rsl_rl.py`
- add regression coverage for the config mapping and required RSL-RL runner fields

## Notes

This provides a runnable baseline rather than claiming per-task RSL-RL tuning. The task-specific settings already present in the DM Control Brax PPO config are preserved where they have direct RSL-RL equivalents, while the remaining runner defaults follow the existing RSL-RL configs in this repository.

## Testing

Added focused tests in `mujoco_playground/_src/dm_control_suite/dm_control_suite_params_test.py`.