### PR TITLE
Defer vision rendering until after autoreset

### DIFF
--- a/mujoco_playground/_src/manipulation/franka_emika_panda/pick_cartesian.py
+++ b/mujoco_playground/_src/manipulation/franka_emika_panda/pick_cartesian.py
@@ -99,6 +99,7 @@ class PandaPickCubeCartesian(pick.PandaPickCube):
 
     mjx_env.MjxEnv.__init__(self, config, config_overrides)
     self._vision = config.vision
+    self._defer_rendering = False
 
     xml_path = (
         mjx_env.ROOT_PATH
@@ -138,6 +139,24 @@ class PandaPickCubeCartesian(pick.PandaPickCube):
           mjm=self._mj_model, **self._config.vision_config.to_dict()
       )
       self._rc_pytree = self._rc.pytree()
+
+  @property
+  def observation_size(self) -> mjx_env.ObservationSize:
+    if self._vision:
+      height, width = self._config.vision_config.cam_res
+      return {'pixels/view_0': (height, width, 3)}
+    return super().observation_size
+
+  def defer_rendering(self) -> None:
+    self._defer_rendering = True
+
+  def render_state(self, state: mjx_env.State) -> mjx_env.State:
+    data = mjx.refit_bvh(self._mjx_model, state.data, self._rc_pytree)
+    out = mjx.render(self._mjx_model, data, self._rc_pytree)
+    rgb = mjx.get_rgb(self._rc_pytree, 0, out[0])
+    brightness = state.info['brightness'][..., None, None, :]
+    rgb = adjust_brightness(rgb, brightness)
+    return state.replace(data=out[2], obs={'pixels/view_0': rgb})
 
   def _post_init(self, obj_name, keyframe):
     super()._post_init(obj_name, keyframe)
@@ -243,16 +262,18 @@ class PandaPickCubeCartesian(pick.PandaPickCube):
       info.update({'brightness': brightness})
 
       data = mjx.forward(self._mjx_model, data)
-      data = mjx.refit_bvh(self._mjx_model, data, self._rc_pytree)
-      out = mjx.render(self._mjx_model, data, self._rc_pytree)
-      data = out[2]
-      rgb = mjx.get_rgb(self._rc_pytree, 0, out[0])
-      rgb = adjust_brightness(rgb, brightness)
-      obs = {'pixels/view_0': rgb}
 
-    return mjx_env.State(
-        data, obs, reward, done, metrics, info  # pyrefly: ignore[bad-argument-type]
+    state = mjx_env.State(
+        data,
+        obs,
+        reward,
+        done,
+        metrics,
+        info,  # pyrefly: ignore[bad-argument-type]
     )  # pyrefly: ignore[bad-argument-type]
+    if self._vision and not self._defer_rendering:
+      state = self.render_state(state)
+    return state
 
   def step(self, state: mjx_env.State, action: jax.Array) -> mjx_env.State:
     """Runs one timestep of the environment's dynamics."""
@@ -377,21 +398,16 @@ class PandaPickCubeCartesian(pick.PandaPickCube):
 
     obs = self._get_obs(data, state.info)
     obs = jp.concat([obs, no_soln.reshape(1), action], axis=0)
-    if self._vision:
-      data = mjx.refit_bvh(self._mjx_model, data, self._rc_pytree)
-      out = mjx.render(self._mjx_model, data, self._rc_pytree)
-      data = out[2]
-      rgb = mjx.get_rgb(self._rc_pytree, 0, out[0])
-      rgb = adjust_brightness(rgb, state.info['brightness'])
-      obs = {'pixels/view_0': rgb}
-
-    return state.replace(  # pyrefly: ignore[missing-attribute]
+    state = state.replace(  # pyrefly: ignore[missing-attribute]
         data=data,
         obs=obs,
         reward=reward,
         done=done.astype(float),
         info=state.info,
     )
+    if self._vision and not self._defer_rendering:
+      state = self.render_state(state)
+    return state
 
   def _get_success(self, data: mjx.Data, info: dict[str, Any]) -> jax.Array:
     box_pos = data.xpos[self._obj_body]

--- a/mujoco_playground/_src/wrapper.py
+++ b/mujoco_playground/_src/wrapper.py
@@ -95,9 +95,9 @@ def wrap_for_brax_training(
 ) -> Wrapper:
   """Common wrapper pattern for all brax training agents.
 
-  Environments that implement `defer_rendering()` and
-  `render_observation(data, obs)` render after episode bookkeeping and
-  autoreset, so cached reset state does not contain pixel observations.
+  Environments that implement `defer_rendering()` and `render_state(state)`
+  render after episode bookkeeping and autoreset, so cached reset state does
+  not contain pixel observations.
 
   Args:
     env: environment to be wrapped
@@ -114,8 +114,8 @@ def wrap_for_brax_training(
     environment did not already have batch dimensions, it is additional Vmap
     wrapped.
   """
-  defer_rendering = hasattr(env, 'defer_rendering') and hasattr(
-      env, 'render_observation'
+  defer_rendering = hasattr(env, 'defer_rendering') and (
+      hasattr(env, 'render_state') or hasattr(env, 'render_observation')
   )
   if defer_rendering:
     env.defer_rendering()
@@ -149,8 +149,11 @@ class DeferredVisionWrapper(Wrapper):
   def _render(self, state: mjx_env.State) -> mjx_env.State:
     info = dict(state.info)
     info[self._OBS_KEY] = state.obs
+    state = state.replace(info=info)
+    if hasattr(self.unwrapped, 'render_state'):
+      return self.unwrapped.render_state(state)
     obs = self.unwrapped.render_observation(state.data, state.obs)
-    return state.replace(obs=obs, info=info)
+    return state.replace(obs=obs)
 
 
 class BraxAutoResetWrapper(Wrapper):

--- a/mujoco_playground/_src/wrapper.py
+++ b/mujoco_playground/_src/wrapper.py
@@ -95,6 +95,10 @@ def wrap_for_brax_training(
 ) -> Wrapper:
   """Common wrapper pattern for all brax training agents.
 
+  Environments that implement `defer_rendering()` and
+  `render_observation(data, obs)` render after episode bookkeeping and
+  autoreset, so cached reset state does not contain pixel observations.
+
   Args:
     env: environment to be wrapped
     episode_length: length of episode
@@ -110,6 +114,11 @@ def wrap_for_brax_training(
     environment did not already have batch dimensions, it is additional Vmap
     wrapped.
   """
+  defer_rendering = hasattr(env, 'defer_rendering') and hasattr(
+      env, 'render_observation'
+  )
+  if defer_rendering:
+    env.defer_rendering()
   if randomization_fn is None:
     env = brax_training.VmapWrapper(env)  # pytype: disable=wrong-arg-types
   else:
@@ -118,7 +127,30 @@ def wrap_for_brax_training(
       env, episode_length, action_repeat  # pyrefly: ignore[bad-argument-type]
   )  # pyrefly: ignore[bad-argument-type, bad-assignment]
   env = BraxAutoResetWrapper(env, full_reset=full_reset)
+  if defer_rendering:
+    env = DeferredVisionWrapper(env)
   return env
+
+
+class DeferredVisionWrapper(Wrapper):
+  """Renders observations after episode bookkeeping and autoreset."""
+
+  _OBS_KEY = 'DeferredVisionWrapper_obs'
+
+  def reset(self, rng: jax.Array) -> mjx_env.State:
+    return self._render(self.env.reset(rng))
+
+  def step(self, state: mjx_env.State, action: jax.Array) -> mjx_env.State:
+    info = dict(state.info)
+    obs = info.pop(self._OBS_KEY)
+    state = self.env.step(state.replace(obs=obs, info=info), action)
+    return self._render(state)
+
+  def _render(self, state: mjx_env.State) -> mjx_env.State:
+    info = dict(state.info)
+    info[self._OBS_KEY] = state.obs
+    obs = self.unwrapped.render_observation(state.data, state.obs)
+    return state.replace(obs=obs, info=info)
 
 
 class BraxAutoResetWrapper(Wrapper):

--- a/mujoco_playground/_src/wrapper_test.py
+++ b/mujoco_playground/_src/wrapper_test.py
@@ -51,8 +51,12 @@ class WrapperTest(parameterized.TestCase):
       def defer_rendering(self):
         self.rendering_deferred = True
 
-      def render_observation(self, data, obs):
-        return {'pixels/view_0': data.qpos[..., :1], 'state': obs}
+      def render_state(self, state):
+        obs = {
+            'pixels/view_0': state.data.qpos[..., :1],
+            'state': state.obs,
+        }
+        return state.replace(obs=obs)
 
       def reset(self, key):
         state = self._env.reset(key)

--- a/mujoco_playground/_src/wrapper_test.py
+++ b/mujoco_playground/_src/wrapper_test.py
@@ -33,6 +33,64 @@ class WrapperTest(parameterized.TestCase):
       ('full_reset', True),
       ('cache_reset', False),
   )
+  def test_deferred_vision_renders_selected_reset_data(self, full_reset):
+    class VisionEnv:
+      """Minimal environment implementing deferred vision hooks."""
+
+      def __init__(self, env):
+        self._env = env
+        self.rendering_deferred = False
+
+      def __getattr__(self, name):
+        return getattr(self._env, name)
+
+      @property
+      def unwrapped(self):
+        return self
+
+      def defer_rendering(self):
+        self.rendering_deferred = True
+
+      def render_observation(self, data, obs):
+        return {'pixels/view_0': data.qpos[..., :1], 'state': obs}
+
+      def reset(self, key):
+        state = self._env.reset(key)
+        return state.replace(obs=state.data.qpos)
+
+      def step(self, state, action):
+        state = self._env.step(state, jp.ones_like(action))
+        return state.replace(
+            obs=state.data.qpos,
+            done=(action[0] > 0).astype(float),
+        )
+
+    vision_env = VisionEnv(
+        dm_control_suite.load(
+            'CartpoleBalance', config_overrides={'impl': 'jax'}
+        )
+    )
+    env = wrapper.wrap_for_brax_training(vision_env, full_reset=full_reset)
+    state = jax.jit(env.reset)(jax.random.PRNGKey(0)[None])
+    first_qpos = state.data.qpos
+
+    self.assertTrue(vision_env.rendering_deferred)
+    self.assertNotIsInstance(state.info['AutoResetWrapper_first_obs'], dict)
+    np.testing.assert_allclose(state.obs['pixels/view_0'], first_qpos[..., :1])
+
+    state = jax.jit(env.step)(state, jp.ones((1, env.action_size)))
+    if full_reset:
+      self.assertFalse(np.allclose(state.data.qpos, first_qpos))
+    else:
+      np.testing.assert_allclose(state.data.qpos, first_qpos, atol=1e-6)
+    np.testing.assert_allclose(
+        state.obs['pixels/view_0'], state.data.qpos[..., :1]
+    )
+
+  @parameterized.named_parameters(
+      ('full_reset', True),
+      ('cache_reset', False),
+  )
   def test_auto_reset_wrapper(self, full_reset):
     """Tests the AutoResetWrapper."""
 


### PR DESCRIPTION
Vision environments currently render inside reset/step before the episode and autoreset wrappers select the final data. With randomized autoreset, this renders both the transition state and the newly reset state even though only the reset state is returned. Cached autoreset also stores and selects full pixel observations.

This adds an opt-in deferred-rendering path for environments that implement `defer_rendering()` and `render_state(state)`. Their state observation passes through the standard wrappers, then one outer wrapper renders from the final selected state. The full state hook preserves MJX renderer sequencing data. The existing observation-only hook remains supported for downstream environments, and environments without either hook are unchanged.

`PandaPickCubeCartesian` now uses the path in vision mode. The regression test covers both cached and full resets under JIT, verifies that the autoreset cache remains state-only, and checks that returned pixels correspond to the selected reset data.

Benchmark on an NVIDIA RTX PRO 6000 Blackwell, using Franka Cartesian vision pick at 64x64 RGB, 1,024 worlds, 16-step compiled scans, episode length 4, and the median of five trials (compilation excluded):

| autoreset | baseline world-steps/s | deferred world-steps/s | speedup | step-time reduction |
|---|---:|---:|---:|---:|
| cached | 139,699 | 139,683 | 1.000x | 0.0% |
| randomized/full | 92,938 | 105,363 | 1.134x | 11.8% |

The neutral cached result is expected because it already performs one render per step. The randomized/full path benefits by eliminating the discarded pre-reset render.

Verified with:
- pre-commit (Pyink, isort, copyright)
- pylint on `wrapper.py` and `pick_cartesian.py` (10.00/10)
- pytype on `wrapper.py` and `pick_cartesian.py`
- `pytest -q mujoco_playground/_src/wrapper_test.py` (7 passed)
- the GPU Franka benchmark above