### PR TITLE
Return optional MJX substep states

### DIFF
--- a/mujoco_playground/_src/mjx_env.py
+++ b/mujoco_playground/_src/mjx_env.py
@@ -192,7 +192,31 @@ def step(
     data: mjx.Data,
     action: jax.Array,
     n_substeps: int = 1,
-) -> mjx.Data:
+    return_substeps: bool = False,
+) -> Union[mjx.Data, Tuple[mjx.Data, mjx.Data]]:
+  """Steps an MJX model, optionally returning every intermediate substep.
+
+  Args:
+    model: MJX model to step.
+    data: Initial MJX data.
+    action: Control values applied at every substep.
+    n_substeps: Number of simulation steps to execute.
+    return_substeps: If true, return ``(final_data, substeps)`` where ``substeps``
+      is an ``mjx.Data`` pytree with a leading axis of length ``n_substeps``.
+      Leave this false when intermediate states are not needed to avoid storing
+      the scan outputs.
+
+  Returns:
+    The final MJX data, or the final data and all intermediate substep data.
+  """
+  if return_substeps:
+    def single_step_with_output(data, _):
+      data = data.replace(ctrl=action)
+      data = mjx.step(model, data)
+      return data, data
+
+    return jax.lax.scan(single_step_with_output, data, (), n_substeps)
+
   def single_step(data, _):
     data = data.replace(ctrl=action)
     data = mjx.step(model, data)

--- a/mujoco_playground/_src/mjx_env_test.py
+++ b/mujoco_playground/_src/mjx_env_test.py
@@ -1,0 +1,53 @@
+# Copyright 2026 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax.numpy as jp
+import mujoco
+import numpy as np
+
+from mujoco_playground._src import mjx_env
+
+
+def _model():
+  return mujoco.MjModel.from_xml_string(
+      """
+      <mujoco>
+        <option timestep="0.01"/>
+        <worldbody>
+          <body>
+            <joint name="hinge" type="hinge"/>
+            <geom type="capsule" size="0.02 0.1"/>
+          </body>
+        </worldbody>
+        <actuator><motor joint="hinge"/></actuator>
+      </mujoco>
+      """
+  )
+
+
+def test_step_can_return_substeps():
+  mj_model = _model()
+  model = mjx_env.put_model(mj_model)
+  data = mjx_env.make_data(mj_model)
+  action = jp.array([0.5])
+
+  final_data, substeps = mjx_env.step(
+      model, data, action, n_substeps=3, return_substeps=True
+  )
+  default_final = mjx_env.step(model, data, action, n_substeps=3)
+
+  assert substeps.time.shape == (3,)
+  np.testing.assert_allclose(substeps.time, jp.array([0.01, 0.02, 0.03]))
+  np.testing.assert_allclose(final_data.qpos, substeps.qpos[-1])
+  np.testing.assert_allclose(default_final.qpos, final_data.qpos)


### PR DESCRIPTION
## Summary

Adds an opt-in `return_substeps` argument to `mjx_env.step` so callers can accumulate rewards or metrics over frame-skipped simulation states.

The existing path is unchanged by default and continues to return only the final `mjx.Data`, without storing scan outputs. With `return_substeps=True`, the function returns `(final_data, substeps)`, where the substep pytree has a leading axis of `n_substeps`.

Addresses #296.

## Tests

- Added a focused MJX regression covering three returned substeps.
- Verified substep times, final-state equality, and backward-compatible default output.
- `pytest mujoco_playground/_src/mjx_env_test.py`: passed.
- Ruff and Pyink checks for the new test file: passed.
